### PR TITLE
Remove 'function_exists' checks

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -7,69 +7,68 @@
  * @package CampSite_2017
  */
 
-if ( ! function_exists( 'campsite_2017_setup' ) ) :
-	/**
-	 * Sets up theme defaults and registers support for various WordPress features.
-	 *
-	 * Note that this function is hooked into the after_setup_theme hook, which
-	 * runs before the init hook. The init hook is too late for some features, such
-	 * as indicating support for post thumbnails.
+
+/**
+ * Sets up theme defaults and registers support for various WordPress features.
+ *
+ * Note that this function is hooked into the after_setup_theme hook, which
+ * runs before the init hook. The init hook is too late for some features, such
+ * as indicating support for post thumbnails.
+ */
+function campsite_2017_setup() {
+	/*
+	 * Make theme available for translation.
+	 * Translations can be filed in the /languages/ directory.
+	 * If you're building a theme based on CampSite 2017, use a find and replace
+	 * to change 'wordcamporg' to the name of your theme in all the template files.
 	 */
-	function campsite_2017_setup() {
-		/*
-		 * Make theme available for translation.
-		 * Translations can be filed in the /languages/ directory.
-		 * If you're building a theme based on CampSite 2017, use a find and replace
-		 * to change 'wordcamporg' to the name of your theme in all the template files.
-		 */
-		load_theme_textdomain( 'wordcamporg', get_theme_file_path( '/languages' ) );
+	load_theme_textdomain( 'wordcamporg', get_theme_file_path( '/languages' ) );
 
-		// Add default posts and comments RSS feed links to head.
-		add_theme_support( 'automatic-feed-links' );
+	// Add default posts and comments RSS feed links to head.
+	add_theme_support( 'automatic-feed-links' );
 
-		/*
-		 * Let WordPress manage the document title.
-		 * By adding theme support, we declare that this theme does not use a
-		 * hard-coded <title> tag in the document head, and expect WordPress to
-		 * provide it for us.
-		 */
-		add_theme_support( 'title-tag' );
+	/*
+	 * Let WordPress manage the document title.
+	 * By adding theme support, we declare that this theme does not use a
+	 * hard-coded <title> tag in the document head, and expect WordPress to
+	 * provide it for us.
+	 */
+	add_theme_support( 'title-tag' );
 
-		/*
-		 * Enable support for Post Thumbnails on posts and pages.
-		 *
-		 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
-		 */
-		add_theme_support( 'post-thumbnails' );
+	/*
+	 * Enable support for Post Thumbnails on posts and pages.
+	 *
+	 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
+	 */
+	add_theme_support( 'post-thumbnails' );
 
-		// This theme uses wp_nav_menu() in two locations.
-		register_nav_menus( array(
-			'primary' => esc_html__( 'Primary', 'wordcamporg' ),
-			'secondary' => esc_html__( 'Secondary', 'wordcamporg' ),
-		) );
+	// This theme uses wp_nav_menu() in two locations.
+	register_nav_menus( array(
+		'primary' => esc_html__( 'Primary', 'wordcamporg' ),
+		'secondary' => esc_html__( 'Secondary', 'wordcamporg' ),
+	) );
 
-		/*
-		 * Switch default core markup for search form, comment form, and comments
-		 * to output valid HTML5.
-		 */
-		add_theme_support( 'html5', array(
-			'search-form',
-			'comment-form',
-			'comment-list',
-			'gallery',
-			'caption',
-		) );
+	/*
+	 * Switch default core markup for search form, comment form, and comments
+	 * to output valid HTML5.
+	 */
+	add_theme_support( 'html5', array(
+		'search-form',
+		'comment-form',
+		'comment-list',
+		'gallery',
+		'caption',
+	) );
 
-		// Set up the WordPress core custom background feature.
-		add_theme_support( 'custom-background', apply_filters( 'campsite_2017_custom_background_args', array(
-			'default-color' => 'ffffff',
-			'default-image' => '',
-		) ) );
+	// Set up the WordPress core custom background feature.
+	add_theme_support( 'custom-background', apply_filters( 'campsite_2017_custom_background_args', array(
+		'default-color' => 'ffffff',
+		'default-image' => '',
+	) ) );
 
-		// Add theme support for selective refresh for widgets.
-		add_theme_support( 'customize-selective-refresh-widgets' );
-	}
-endif;
+	// Add theme support for selective refresh for widgets.
+	add_theme_support( 'customize-selective-refresh-widgets' );
+}
 add_action( 'after_setup_theme', 'campsite_2017_setup' );
 
 /**

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -29,28 +29,27 @@ function campsite_2017_custom_header_setup() {
 }
 add_action( 'after_setup_theme', 'campsite_2017_custom_header_setup' );
 
-if ( ! function_exists( 'campsite_2017_header_style' ) ) :
-	/**
-	 * Styles the header image and text displayed on the blog.
-	 *
-	 * @see campsite_2017_custom_header_setup().
+/**
+ * Styles the header image and text displayed on the blog.
+ *
+ * @see campsite_2017_custom_header_setup().
+ */
+function campsite_2017_header_style() {
+	$header_text_color = get_header_textcolor();
+
+	/*
+	 * If no custom options for text are set, let's bail.
+	 * get_header_textcolor() options: Any hex value, 'blank' to hide text. Default: add_theme_support( 'custom-header' ).
 	 */
-	function campsite_2017_header_style() {
-		$header_text_color = get_header_textcolor();
+	if ( get_theme_support( 'custom-header', 'default-text-color' ) === $header_text_color ) {
+		return;
+	}
 
-		/*
-		 * If no custom options for text are set, let's bail.
-		 * get_header_textcolor() options: Any hex value, 'blank' to hide text. Default: add_theme_support( 'custom-header' ).
-		 */
-		if ( get_theme_support( 'custom-header', 'default-text-color' ) === $header_text_color ) {
-			return;
-		}
+	// If we get this far, we have custom styles. Let's do this.
+	?>
 
-		// If we get this far, we have custom styles. Let's do this.
-		?>
-		<style type="text/css">
+	<style type="text/css">
 		<?php
-			// Has the text been hidden?
 		if ( ! display_header_text() ) : ?>
 			.site-title,
 			.site-description {
@@ -58,7 +57,7 @@ if ( ! function_exists( 'campsite_2017_header_style' ) ) :
 				clip: rect(1px, 1px, 1px, 1px);
 			}
 		<?php
-			// If the user has set a custom color for the text use that.
+			// If the user has set a custom color for the text, use that.
 			else :
 		?>
 			.site-title a,
@@ -66,11 +65,10 @@ if ( ! function_exists( 'campsite_2017_header_style' ) ) :
 				color: #<?php echo esc_attr( $header_text_color ); ?>;
 			}
 		<?php endif; ?>
-		</style>
-		<?php
-	}
-endif;
+	</style>
 
+	<?php
+}
 
 /**
  * Customize video play/pause button in the custom header.

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -7,76 +7,72 @@
  * @package CampSite_2017
  */
 
-if ( ! function_exists( 'campsite_2017_posted_on' ) ) :
-	/**
-	 * Prints HTML with meta information for the current post-date/time and author.
-	 */
-	function campsite_2017_posted_on() {
-		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
-		if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
-		}
 
-		$time_string = sprintf( $time_string,
-			esc_attr( get_the_date( 'c' ) ),
-			esc_html( get_the_date() ),
-			esc_attr( get_the_modified_date( 'c' ) ),
-			esc_html( get_the_modified_date() )
-		);
-
-		$posted_on = sprintf(
-			esc_html_x( 'Posted on %s', 'post date', 'wordcamporg' ),
-			'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
-		);
-
-		$byline = sprintf(
-			esc_html_x( 'by %s', 'post author', 'wordcamporg' ),
-			'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
-		);
-
-		echo '<span class="posted-on">' . $posted_on . '</span><span class="byline"> ' . $byline . '</span>'; // WPCS: XSS OK.
-
+/**
+ * Prints HTML with meta information for the current post-date/time and author.
+ */
+function campsite_2017_posted_on() {
+	$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+	if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
+		$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
 	}
-endif;
 
-if ( ! function_exists( 'campsite_2017_entry_footer' ) ) :
-	/**
-	 * Prints HTML with meta information for the categories, tags and comments.
-	 */
-	function campsite_2017_entry_footer() {
-		// Hide category and tag text for pages.
-		if ( 'post' === get_post_type() ) {
-			/* translators: used between list items, there is a space after the comma */
-			$categories_list = get_the_category_list( esc_html__( ', ', 'wordcamporg' ) );
-			if ( $categories_list && campsite_2017_categorized_blog() ) {
-				printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'wordcamporg' ) . '</span>', $categories_list ); // WPCS: XSS OK.
-			}
+	$time_string = sprintf( $time_string,
+		esc_attr( get_the_date( 'c' ) ),
+		esc_html( get_the_date() ),
+		esc_attr( get_the_modified_date( 'c' ) ),
+		esc_html( get_the_modified_date() )
+	);
 
-			/* translators: used between list items, there is a space after the comma */
-			$tags_list = get_the_tag_list( '', esc_html__( ', ', 'wordcamporg' ) );
-			if ( $tags_list ) {
-				printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'wordcamporg' ) . '</span>', $tags_list ); // WPCS: XSS OK.
-			}
+	$posted_on = sprintf(
+		esc_html_x( 'Posted on %s', 'post date', 'wordcamporg' ),
+		'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
+	);
+
+	$byline = sprintf(
+		esc_html_x( 'by %s', 'post author', 'wordcamporg' ),
+		'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
+	);
+
+	echo '<span class="posted-on">' . $posted_on . '</span><span class="byline"> ' . $byline . '</span>'; // WPCS: XSS OK.
+}
+
+/**
+ * Prints HTML with meta information for the categories, tags and comments.
+ */
+function campsite_2017_entry_footer() {
+	// Hide category and tag text for pages.
+	if ( 'post' === get_post_type() ) {
+		/* translators: used between list items, there is a space after the comma */
+		$categories_list = get_the_category_list( esc_html__( ', ', 'wordcamporg' ) );
+		if ( $categories_list && campsite_2017_categorized_blog() ) {
+			printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'wordcamporg' ) . '</span>', $categories_list ); // WPCS: XSS OK.
 		}
 
-		if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
-			echo '<span class="comments-link">';
-			/* translators: %s: post title */
-			comments_popup_link( sprintf( wp_kses( __( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', 'wordcamporg' ), array( 'span' => array( 'class' => array() ) ) ), get_the_title() ) );
-			echo '</span>';
+		/* translators: used between list items, there is a space after the comma */
+		$tags_list = get_the_tag_list( '', esc_html__( ', ', 'wordcamporg' ) );
+		if ( $tags_list ) {
+			printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'wordcamporg' ) . '</span>', $tags_list ); // WPCS: XSS OK.
 		}
-
-		edit_post_link(
-			sprintf(
-				/* translators: %s: Name of current post */
-				esc_html__( 'Edit %s', 'wordcamporg' ),
-				the_title( '<span class="screen-reader-text">"', '"</span>', false )
-			),
-			'<span class="edit-link">',
-			'</span>'
-		);
 	}
-endif;
+
+	if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
+		echo '<span class="comments-link">';
+		/* translators: %s: post title */
+		comments_popup_link( sprintf( wp_kses( __( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', 'wordcamporg' ), array( 'span' => array( 'class' => array() ) ) ), get_the_title() ) );
+		echo '</span>';
+	}
+
+	edit_post_link(
+		sprintf(
+			/* translators: %s: Name of current post */
+			esc_html__( 'Edit %s', 'wordcamporg' ),
+			the_title( '<span class="screen-reader-text">"', '"</span>', false )
+		),
+		'<span class="edit-link">',
+		'</span>'
+	);
+}
 
 /**
  * Returns true if a blog has more than 1 category.


### PR DESCRIPTION
Since we're not distributing this theme, we don't have to worry about conflicting functions, especially since they're prefixed. Having the extra condition and indentation hurts readability.