### PR TITLE
Late-escape variables

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -31,14 +31,17 @@ if ( post_password_required() ) {
 
 			if ( '1' === $comments_number ) {
 				/* translators: %s: post title */
-				printf( _x( 'One Reply to &ldquo;%s&rdquo;', 'comments title', 'twentyseventeen' ), get_the_title() ); // WPCS: XSS OK.
+				echo wp_kses( sprintf(
+					_x( 'One Reply to &ldquo;%s&rdquo;', 'comments title', 'twentyseventeen' ),
+					get_the_title()
+				), wp_kses_allowed_html( 'data' ) );
 			} else {
-				printf( // WPCS: XSS OK.
+				echo wp_kses( sprintf(
 					/* translators: 1: number of comments, 2: post title */
-					_nx( '%1$s Reply to &ldquo;%2$s&rdquo;', '%1$s Replies to &ldquo;%2$s&rdquo;', $comments_number, 'comments title', 'wordcamporg' ),
+					_nx( '%1$s Reply to &ldquo;%2$s&rdquo;', '%1$s Replies to &ldquo;%2$s&rdquo;', absint( $comments_number ), 'comments title', 'wordcamporg' ),
 					number_format_i18n( $comments_number ),
 					get_the_title()
-				);
+				), wp_kses_allowed_html( 'data' ) );
 			}
 			?>
 		</h2><!-- .comments-title -->

--- a/comments.php
+++ b/comments.php
@@ -31,17 +31,17 @@ if ( post_password_required() ) {
 
 			if ( '1' === $comments_number ) {
 				/* translators: %s: post title */
-				echo wp_kses( sprintf(
+				echo wp_kses_data( sprintf(
 					_x( 'One Reply to &ldquo;%s&rdquo;', 'comments title', 'wordcamporg' ),
 					get_the_title()
-				), wp_kses_allowed_html( 'data' ) );
+				) );
 			} else {
-				echo wp_kses( sprintf(
+				echo wp_kses_data( sprintf(
 					/* translators: 1: number of comments, 2: post title */
 					_nx( '%1$s Reply to &ldquo;%2$s&rdquo;', '%1$s Replies to &ldquo;%2$s&rdquo;', absint( $comments_number ), 'comments title', 'wordcamporg' ),
 					number_format_i18n( $comments_number ),
 					get_the_title()
-				), wp_kses_allowed_html( 'data' ) );
+				) );
 			}
 			?>
 		</h2><!-- .comments-title -->

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -45,13 +45,13 @@ function campsite_2017_entry_footer() {
 		/* translators: used between list items, there is a space after the comma */
 		$categories_list = get_the_category_list( esc_html__( ', ', 'wordcamporg' ) );
 		if ( $categories_list && campsite_2017_categorized_blog() ) {
-			printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'wordcamporg' ) . '</span>', $categories_list ); // WPCS: XSS OK.
+			printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'wordcamporg' ) . '</span>', wp_kses( $categories_list, wp_kses_allowed_html( 'data' ) ) );
 		}
 
 		/* translators: used between list items, there is a space after the comma */
 		$tags_list = get_the_tag_list( '', esc_html__( ', ', 'wordcamporg' ) );
 		if ( $tags_list ) {
-			printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'wordcamporg' ) . '</span>', $tags_list ); // WPCS: XSS OK.
+			printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'wordcamporg' ) . '</span>', wp_kses( $tags_list, wp_kses_allowed_html( 'data' ) ) );
 		}
 	}
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -45,13 +45,13 @@ function campsite_2017_entry_footer() {
 		/* translators: used between list items, there is a space after the comma */
 		$categories_list = get_the_category_list( esc_html__( ', ', 'wordcamporg' ) );
 		if ( $categories_list && campsite_2017_categorized_blog() ) {
-			printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'wordcamporg' ) . '</span>', wp_kses( $categories_list, wp_kses_allowed_html( 'data' ) ) );
+			printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'wordcamporg' ) . '</span>', wp_kses_data( $categories_list ) );
 		}
 
 		/* translators: used between list items, there is a space after the comma */
 		$tags_list = get_the_tag_list( '', esc_html__( ', ', 'wordcamporg' ) );
 		if ( $tags_list ) {
-			printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'wordcamporg' ) . '</span>', wp_kses( $tags_list, wp_kses_allowed_html( 'data' ) ) );
+			printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'wordcamporg' ) . '</span>', wp_kses_data( $tags_list ) );
 		}
 	}
 

--- a/sidebar-before-content.php
+++ b/sidebar-before-content.php
@@ -31,7 +31,7 @@ if ( is_front_page() ) {
 			foreach ( range( 1, 5 ) as $index ) {
 				if ( is_active_sidebar( 'before-content-day-of-' . $index ) ) {
 					?>
-					<div id="content-widget-<?php echo $index; /* WPCS: xss ok. */ ?>" class="content-widgets-block">
+					<div id="content-widget-<?php echo absint( $index ); ?>" class="content-widgets-block">
 						<?php dynamic_sidebar( 'before-content-day-of-' . $index ); ?>
 					</div>
 					<?php
@@ -55,7 +55,7 @@ if ( is_front_page() ) {
 			foreach ( range( 1, 5 ) as $index ) {
 				if ( is_active_sidebar( 'before-content-homepage-' . $index ) ) {
 					?>
-					<div id="content-widget-<?php echo $index; /* WPCS: xss ok. */ ?>" class="content-widgets-block">
+					<div id="content-widget-<?php echo absint( $index ); ?>" class="content-widgets-block">
 						<?php dynamic_sidebar( 'before-content-homepage-' . $index ); ?>
 					</div>
 					<?php

--- a/sidebar-footer.php
+++ b/sidebar-footer.php
@@ -20,7 +20,7 @@ if ( is_active_sidebar( 'footer-1' )
 		foreach ( range( 1, 5 ) as $index ) {
 			if ( is_active_sidebar( 'footer-' . $index ) ) {
 				?>
-				<div id="footer-widget-<?php echo $index; /* WPCS: xss ok. */ ?>" class="footer-widgets-block">
+				<div id="footer-widget-<?php echo absint( $index ); ?>" class="footer-widgets-block">
 					<?php dynamic_sidebar( 'footer-' . $index ); ?>
 				</div>
 				<?php

--- a/sidebar-header.php
+++ b/sidebar-header.php
@@ -20,7 +20,7 @@ if ( is_active_sidebar( 'header-1' )
 		foreach ( range( 1, 5 ) as $index ) {
 			if ( is_active_sidebar( 'header-' . $index ) ) {
 				?>
-				<div id="header-widget-<?php echo $index; /* WPCS: xss ok. */ ?>" class="header-widgets-block">
+				<div id="header-widget-<?php echo absint( $index ); ?>" class="header-widgets-block">
 					<?php dynamic_sidebar( 'header-' . $index ); ?>
 				</div>
 				<?php

--- a/template-parts/header/site-branding.php
+++ b/template-parts/header/site-branding.php
@@ -19,6 +19,6 @@
 	<?php $description = get_bloginfo( 'description', 'display' ); ?>
 
 	<?php if ( $description || is_customize_preview() ) : ?>
-		<p class="site-description"><?php echo $description; /* WPCS: xss ok. */ ?></p>
+		<p class="site-description"><?php echo esc_html( $description ); ?></p>
 	<?php endif; ?>
 </div><!-- .site-branding -->


### PR DESCRIPTION
For WordCamp.org, we try to late-escape everything.

https://vip.wordpress.com/2014/06/20/the-importance-of-escaping-all-the-things/

I left a few things whitelisted with PHPCS, though, just because it'd need heavy refactoring (because of the way _s generates the markup), so it's not worth the trouble.